### PR TITLE
feat: add relaxed rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ DML_DEBUG=1 npx do-me-lint
 | ------------------------------------------------ | --------------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------- |
 | semi <br> <small>`boolean`</small>               | Force semicolons to be required (`true`) or forbidden (`false`) |                                                                            | DML_SEMI <br> <small>`"1"` (other values are false)</small>   |
 | ignoredRules <br> <small>`Array<string>`</small> | Ignored rules <br> <small>will be not added</small>             |                                                                            | DML_IGNORED_RULES<br> <small>`comma-separated string`</small> |
+| relaxedRules <br> <small>`Array<string>`</small> | Relaxed rules <br> <small>generate warnings</small>             |                                                                            | DML_RELAXED_RULES<br> <small>`comma-separated string`</small> |
 | jestFiles<br> <small>`string`</small>            | Pattern for Jest specs                                          | <small> `src/**/{__tests__/*,*.{spec,test}}`<br>`.{js,ts,jsx,tsx}`</small> | DML_JEST_FILES <br> <small>`string`</small>                   |
 | —                                                | Extended debug info                                             |                                                                            | DML_DEBUG <br> <small>`"1"` (other values are false)</small>  |
 
@@ -94,8 +95,11 @@ Your `.domelintrc.yml` may look like this:
 semi: true
 ignoredRules:
   - max-params
-  - func-names
   - prefer-template
+
+# generate warnings instead of errors  
+relaxedRules:
+  - func-names
 ```
 
 ## Supported ESLint plugins

--- a/src/controllers/doMeESLint.ts
+++ b/src/controllers/doMeESLint.ts
@@ -14,6 +14,7 @@ export const doMeESLint = async (context: Context): Promise<void> => {
     projectDependencies: context.installedPackages.map(installedPackage => installedPackage.name),
     patterns: context.patterns,
     ignoredRules: context.ignoredRules,
+    relaxedRules: context.relaxedRules,
     semi: context.semi,
   })
 

--- a/src/controllers/getMeContext.ts
+++ b/src/controllers/getMeContext.ts
@@ -33,6 +33,7 @@ export interface Context {
   monorepoRoot?: string
   patterns: Patterns
   ignoredRules: string[]
+  relaxedRules: string[]
   dependencyManager?: DependencyManager
   semi: boolean
   gitignore: string[]
@@ -56,7 +57,7 @@ export const getMeContext = (): Context => {
     log.debug(`monorepo root:\t${monorepoRoot}`)
   }
 
-  const { ignoredRules, semi, debug } = settings
+  const { ignoredRules, relaxedRules, semi, debug } = settings
 
   const patterns = getPatterns(settings)
   const packageJson = getPackageJson(projectDirectory)
@@ -78,6 +79,7 @@ export const getMeContext = (): Context => {
     monorepoRoot,
     patterns,
     ignoredRules,
+    relaxedRules,
     semi,
     gitignore,
     debug,

--- a/src/lib/context/paths.test.ts
+++ b/src/lib/context/paths.test.ts
@@ -7,6 +7,7 @@ test('should return values from settings', () => {
     semi: true,
     debug: false,
     ignoredRules: ['fizz', 'buzz'],
+    relaxedRules: ['fizz1', 'buzz1'],
   }
   expect(getPatterns(settings)).toHaveProperty('jestFiles', 'foo')
 })

--- a/src/lib/context/settings.ts
+++ b/src/lib/context/settings.ts
@@ -32,6 +32,7 @@ const getRcSettings = (projectDirectory: string): JsonObject => {
 export interface Settings {
   jestFiles: string[] | string
   ignoredRules: string[]
+  relaxedRules: string[]
   semi: boolean
   debug: boolean
 }
@@ -52,6 +53,18 @@ export const getSettings = (projectDirectory: string): Settings => {
     ignoredRules = []
   }
 
+  let relaxedRules: string[]
+  if (process.env.DML_RELAXED_RULES !== undefined) {
+    relaxedRules = process.env.DML_RELAXED_RULES.toString().split(',')
+  } else if (
+    Array.isArray(rcSettings.relaxedRules) &&
+    rcSettings.relaxedRules.every(value => typeof value === 'string')
+  ) {
+    relaxedRules = rcSettings.relaxedRules as string[]
+  } else {
+    relaxedRules = []
+  }
+
   let semi: boolean
   if (process.env.DML_SEMI !== undefined) {
     semi = process.env.DML_SEMI === '1'
@@ -68,6 +81,7 @@ export const getSettings = (projectDirectory: string): Settings => {
       rcSettings.jestFiles?.toString() ??
       'src/**/{__tests__/*,*.{spec,test}}.{js,ts,jsx,tsx}',
     ignoredRules,
+    relaxedRules,
     semi,
     debug: process.env.DML_DEBUG === '1',
   }

--- a/src/lib/eslint/getConfig.ts
+++ b/src/lib/eslint/getConfig.ts
@@ -18,6 +18,7 @@ import { getProperty } from './rulesConfig'
 interface Parameters {
   projectDependencies: string[]
   ignoredRules: string[]
+  relaxedRules: string[]
   patterns: Patterns
   semi: boolean
 }
@@ -27,10 +28,11 @@ interface Result {
   dependencies: ExactDependency[]
 }
 export const getConfig = (parameters: Parameters): Result => {
-  const { projectDependencies, ignoredRules, patterns, semi } = parameters
+  const { projectDependencies, ignoredRules, relaxedRules, patterns, semi } = parameters
   const rules = getRules({
     projectDependencies,
     ignoredRules,
+    relaxedRules,
     semi,
   })
   const plugins = getPlugins(projectDependencies)
@@ -96,11 +98,13 @@ const buildValue = ({ options, level }: BuildValueParameters): RuleValue => {
 interface GetRulesParameters {
   projectDependencies: string[]
   ignoredRules: string[]
+  relaxedRules: string[]
   semi: boolean
 }
 const getRules = ({
   projectDependencies,
   ignoredRules,
+  relaxedRules,
   semi,
 }: GetRulesParameters): ByScope<ESLintRules> => {
   const input = { projectDependencies, semi }
@@ -115,7 +119,7 @@ const getRules = ({
       const enabled = getProperty(rule.enabled, input)
       const options = getProperty(rule.options, input)
       const scope = rule.scope || 'all'
-      const level = 'error'
+      const level = relaxedRules.includes(rulename) ? 'warn' : 'error'
 
       if (!enabled) {
         return false


### PR DESCRIPTION
# Add 'relaxedRules' Feature for Custom Rule Level Control

## Overview
This pull request introduces a new feature to the `do-me-lint` library, enhancing its flexibility and usability. It currently lacks the ability to control the severity level of individual linting rules, defaulting all rules to the "error" level.

## Feature Description
The proposed feature, named `relaxedRules`, allows users to specify certain rules to be demoted from "error" to "warn" level. This feature is implemented in a manner similar to the existing `ignoredRules` feature. While `ignoredRules` lets users completely skip specific rules, `relaxedRules` provides a more nuanced approach, reducing the severity of chosen rules without entirely disabling them.

## Implementation
- **Relaxed Rules Logic:** The logic for `relaxedRules` mirrors that of `ignoredRules`. Users can list the rules they wish to relax in their configuration.
- **Configuration Update:** The eslint configuration generation logic has been updated to incorporate `relaxedRules`. When generating the eslint config, the tool now sets the listed rules to "warn" instead of "error".
- **Backward Compatibility:** This update maintains backward compatibility. Existing functionality, including `ignoredRules`, remains unaffected.

## Benefits
- **Increased Flexibility:** Users can now tailor the linting severity to their project's needs, opting for warnings in cases where errors are too strict.
- **Improved Developer Experience:** This feature allows developers to prioritize fixing critical issues by reducing the noise from less critical linting rules.
- **Customizable Workflow:** Teams can adjust their linting strategy over time, starting with warnings for new rules and escalating them to errors as the codebase matures.

## Usage Example
To use `relaxedRules`, simply add the desired rules to the configuration as shown below:

```yaml
relaxedRules:
  - func-names
```